### PR TITLE
feat: added label to the metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ PAT
 ```sh
 docker run -d \
     -e GITHUB_AUTH_TYPE=PAT \
-    -e GITHUB_APP_NAME=name_of_my_app
+    -e GITHUB_ACCOUNT_NAME=name_of_my_app
     -e GITHUB_TOKEN=my_token \
     -p 2112:2112 \
     ghcr.io/kalgurn/grl-exporter:latest
@@ -35,7 +35,7 @@ docker run -d \
     -e GITHUB_AUTH_TYPE=APP \
     -e GITHUB_APP_ID=my_app_id \
     -e GITHUB_INSTALLATION_ID=my_app_installation_id \
-    -e GITHUB_APP_NAME=name_of_my_app
+    -e GITHUB_ACCOUNT_NAME=name_of_my_app
     -e GITHUB_PRIVATE_KEY_PATH=/tmp
     -v $PWD/path_to/key.pem:/tmp/key.pem
     -p 2112:2112 \

--- a/internal/prometheus_exporter/server_test.go
+++ b/internal/prometheus_exporter/server_test.go
@@ -20,13 +20,13 @@ type FakeCollector struct {
 
 func newFakeCollector() *LimitsCollector {
 	return &LimitsCollector{
-		LimitTotal: prometheus.NewDesc(prometheus.BuildFQName(github_app, "", "limit_total"),
+		LimitTotal: prometheus.NewDesc(prometheus.BuildFQName(githubAccount, "", "limit_total"),
 			"Total limit of requests for the installation",
 			nil, nil),
-		LimitRemaining: prometheus.NewDesc(prometheus.BuildFQName(github_app, "", "limit_remaining"),
+		LimitRemaining: prometheus.NewDesc(prometheus.BuildFQName(githubAccount, "", "limit_remaining"),
 			"Amount of remaining requests for the installation",
 			nil, nil),
-		LimitUsed: prometheus.NewDesc(prometheus.BuildFQName(github_app, "", "limit_used"),
+		LimitUsed: prometheus.NewDesc(prometheus.BuildFQName(githubAccount, "", "limit_used"),
 			"Amount of used requests for the installation",
 			nil, nil),
 	}
@@ -40,7 +40,7 @@ func (collector *FakeCollector) Describe(ch chan<- *prometheus.Desc) {
 
 func (collector *FakeCollector) Collect(ch chan<- prometheus.Metric) {
 
-	log.Printf("Collecting metrics for %s", github_app)
+	log.Printf("Collecting metrics for %s", githubAccount)
 	//Write latest value for each metric in the prometheus metric channel.
 	//Note that you can pass CounterValue, GaugeValue, or UntypedValue types here.
 	m1 := prometheus.MustNewConstMetric(collector.LimitTotal, prometheus.GaugeValue, float64(10))


### PR DESCRIPTION
Updated the metrics by setting a label **account**. Now the metrics are having generic names. This is allowing to generalize the metrics collection and a dashboards composition. 
Now, if you have more than one PAT/APP used, you don't need to search a specific metric called $account_github_limits_used. Instead you can just add the metric _github_limit_used_ and sort it by label.

A grafana example
<img width="704" alt="image" src="https://user-images.githubusercontent.com/38934525/146818969-354e1db1-00f6-41b9-8504-049878eff06f.png">

The top panel shows all applications which are reporting the metric _github_limit_used_ while the bottom one sorts the result based on a label from the dropdown **account** variable
<img width="704" alt="image" src="https://user-images.githubusercontent.com/38934525/146819190-d3dea724-9b1b-46e5-83c9-a5fdd3142ddf.png">

Thanks @davidk81 for the feedback and the idea