### PR TITLE
Add health_check endpoint

### DIFF
--- a/internal/prometheus_exporter/server.go
+++ b/internal/prometheus_exporter/server.go
@@ -1,6 +1,7 @@
 package prometheus_exporter
 
 import (
+	"fmt"
 	"log"
 	"net/http"
 	"time"
@@ -60,11 +61,18 @@ func (collector *LimitsCollector) Collect(ch chan<- prometheus.Metric) {
 	ch <- m3
 }
 
+// healthCheckHandler returns a positive 200 OK response to any GET request, indicating
+// that the server is alive and serving requests.
+func healthCheckHandler(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintln(w, "healthy")
+}
+
 func Run() {
 	limit := newLimitsCollector()
 	prometheus.NewRegistry()
 	prometheus.MustRegister(limit)
 
 	http.Handle("/metrics", promhttp.Handler())
+	http.HandleFunc("/health_check", healthCheckHandler)
 	http.ListenAndServe(":2112", nil)
 }


### PR DESCRIPTION
Add a simple `health_check` endpoint to be used as kubernetes [liveness](https://cloud.google.com/blog/products/containers-kubernetes/kubernetes-best-practices-setting-up-health-checks-with-readiness-and-liveness-probes) endpoint.