### PR TITLE
Add metric for the time left until bucket gets reset

### DIFF
--- a/internal/github_client/github_client.go
+++ b/internal/github_client/github_client.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/bradleyfalzon/ghinstallation/v2"
 	"github.com/google/go-github/github"
@@ -21,9 +22,10 @@ func GetRemainingLimits(c *github.Client) RateLimits {
 	}
 
 	return RateLimits{
-		Limit:     limits.Core.Limit,
-		Remaining: limits.Core.Remaining,
-		Used:      limits.Core.Limit - limits.Core.Remaining,
+		Limit:       limits.Core.Limit,
+		Remaining:   limits.Core.Remaining,
+		Used:        limits.Core.Limit - limits.Core.Remaining,
+		SecondsLeft: time.Until(limits.Core.Reset.Time).Seconds(),
 	}
 }
 

--- a/internal/github_client/github_client_test.go
+++ b/internal/github_client/github_client_test.go
@@ -1,8 +1,10 @@
 package github_client
 
 import (
+	"math"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/google/go-github/github"
 	"github.com/migueleliasweb/go-github-mock/src/mock"
@@ -11,9 +13,10 @@ import (
 
 func TestGetRemainingLimits(t *testing.T) {
 	var (
-		limit     = 100
-		remaining = 63
-		used      = 37
+		limit        = 100
+		remaining    = 63
+		used         = 37
+		seconds_left = 1500
 	)
 	mockedHTTPClient := mock.NewMockedHTTPClient(
 		mock.WithRequestMatch(
@@ -25,7 +28,7 @@ func TestGetRemainingLimits(t *testing.T) {
 					Core: &github.Rate{
 						Limit:     limit,
 						Remaining: remaining,
-						Reset:     github.Timestamp{},
+						Reset:     github.Timestamp{Time: time.Now().Add(time.Second * time.Duration(seconds_left))},
 					},
 					Search: &github.Rate{},
 				},
@@ -38,10 +41,12 @@ func TestGetRemainingLimits(t *testing.T) {
 	assert.Equal(t, limit, limits.Limit, "The limits should be equal")
 	assert.Equal(t, remaining, limits.Remaining, "The remaining limits should be equal")
 	assert.Equal(t, used, limits.Used, "The used value should be equal")
+	assert.Equal(t, seconds_left, int(math.Ceil(limits.SecondsLeft)), "The seconds left value should be equal")
 
 	assert.NotEqual(t, 99, limits.Limit, "The limit should not be equal")
 	assert.NotEqual(t, 99, limits.Remaining, "The remaining limits should not be equal")
 	assert.NotEqual(t, 18, limits.Used, "The used value should not be equal")
+	assert.NotEqual(t, 18, limits.Used, "The seconds left value should not be equal")
 }
 
 func TestInitConfigApp(t *testing.T) {

--- a/internal/github_client/types.go
+++ b/internal/github_client/types.go
@@ -13,9 +13,10 @@ type TokenConfig struct {
 }
 
 type RateLimits struct {
-	Limit     int
-	Remaining int
-	Used      int
+	Limit       int
+	Remaining   int
+	Used        int
+	SecondsLeft float64
 }
 
 type GithubClient interface {

--- a/internal/prometheus_exporter/server.go
+++ b/internal/prometheus_exporter/server.go
@@ -32,6 +32,11 @@ func newLimitsCollector() *LimitsCollector {
 			nil, prometheus.Labels{
 				"account": githubAccount,
 			}),
+		SecondsLeft: prometheus.NewDesc(prometheus.BuildFQName("github", "limit", "time_left_seconds"),
+			"Time left in seconds until rate limit gets reset for the installation",
+			nil, prometheus.Labels{
+				"account": githubAccount,
+			}),
 	}
 }
 
@@ -39,6 +44,7 @@ func (collector *LimitsCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- collector.LimitTotal
 	ch <- collector.LimitRemaining
 	ch <- collector.LimitUsed
+	ch <- collector.SecondsLeft
 }
 
 func (collector *LimitsCollector) Collect(ch chan<- prometheus.Metric) {
@@ -52,12 +58,15 @@ func (collector *LimitsCollector) Collect(ch chan<- prometheus.Metric) {
 	m1 := prometheus.MustNewConstMetric(collector.LimitTotal, prometheus.GaugeValue, float64(limits.Limit))
 	m2 := prometheus.MustNewConstMetric(collector.LimitRemaining, prometheus.GaugeValue, float64(limits.Remaining))
 	m3 := prometheus.MustNewConstMetric(collector.LimitUsed, prometheus.GaugeValue, float64(limits.Used))
+	m4 := prometheus.MustNewConstMetric(collector.SecondsLeft, prometheus.GaugeValue, limits.SecondsLeft)
 	m1 = prometheus.NewMetricWithTimestamp(time.Now(), m1)
 	m2 = prometheus.NewMetricWithTimestamp(time.Now(), m2)
 	m3 = prometheus.NewMetricWithTimestamp(time.Now(), m3)
+	m4 = prometheus.NewMetricWithTimestamp(time.Now(), m4)
 	ch <- m1
 	ch <- m2
 	ch <- m3
+	ch <- m4
 }
 
 func Run() {

--- a/internal/prometheus_exporter/server_test.go
+++ b/internal/prometheus_exporter/server_test.go
@@ -16,6 +16,7 @@ type FakeCollector struct {
 	LimitTotal     *prometheus.Desc
 	LimitRemaining *prometheus.Desc
 	LimitUsed      *prometheus.Desc
+	SecondsLeft    *prometheus.Desc
 }
 
 func newFakeCollector() *LimitsCollector {
@@ -29,6 +30,9 @@ func newFakeCollector() *LimitsCollector {
 		LimitUsed: prometheus.NewDesc(prometheus.BuildFQName(githubAccount, "", "limit_used"),
 			"Amount of used requests for the installation",
 			nil, nil),
+		SecondsLeft: prometheus.NewDesc(prometheus.BuildFQName(githubAccount, "", "seconds_left"),
+			"Time left in seconds until limit is reset for the installation",
+			nil, nil),
 	}
 }
 
@@ -36,6 +40,7 @@ func (collector *FakeCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- collector.LimitTotal
 	ch <- collector.LimitRemaining
 	ch <- collector.LimitUsed
+	ch <- collector.SecondsLeft
 }
 
 func (collector *FakeCollector) Collect(ch chan<- prometheus.Metric) {
@@ -46,12 +51,15 @@ func (collector *FakeCollector) Collect(ch chan<- prometheus.Metric) {
 	m1 := prometheus.MustNewConstMetric(collector.LimitTotal, prometheus.GaugeValue, float64(10))
 	m2 := prometheus.MustNewConstMetric(collector.LimitRemaining, prometheus.GaugeValue, float64(6))
 	m3 := prometheus.MustNewConstMetric(collector.LimitUsed, prometheus.GaugeValue, float64(4))
+	m4 := prometheus.MustNewConstMetric(collector.SecondsLeft, prometheus.GaugeValue, time.Duration(time.Second*30).Seconds())
 	m1 = prometheus.NewMetricWithTimestamp(time.Now().Add(-time.Hour), m1)
 	m2 = prometheus.NewMetricWithTimestamp(time.Now(), m2)
 	m3 = prometheus.NewMetricWithTimestamp(time.Now(), m3)
+	m4 = prometheus.NewMetricWithTimestamp(time.Now(), m4)
 	ch <- m1
 	ch <- m2
 	ch <- m3
+	ch <- m4
 }
 
 func TestNewLimitsCollector(t *testing.T) {

--- a/internal/prometheus_exporter/types.go
+++ b/internal/prometheus_exporter/types.go
@@ -6,4 +6,5 @@ type LimitsCollector struct {
 	LimitTotal     *prometheus.Desc
 	LimitRemaining *prometheus.Desc
 	LimitUsed      *prometheus.Desc
+	SecondsLeft    *prometheus.Desc
 }


### PR DESCRIPTION
Hi!

We've been playing around with this exporter to monitor some of our GitHub accounts at Grafana, but were missing a way to anticipate resets. So we forked it and expanded it a bit. (And I accidentally opened a couple of PRs back to you while at it, sorry about the spam 😅 ).

GitHub's Rate Limit API returns a numeric value representing a Unix epoch, which isn't very useful as a metric. Google's github client casts it to a timestamp. Building upon that, I've added code to turn that timestamp into a metric of the number of seconds left until the expected reset.

We've been trying it out for a few days and the graph is behaving as we would expect, regularly going down from 3600 to 0.

![image](https://user-images.githubusercontent.com/16037215/227185282-a9dd3a3f-a2a9-4b46-8328-10cc3bd88b5f.png)

This metric allows for dashboards to provide information not only about current usage, but also to be able to anticipate to some extent whether or not any user will be rate limited before the end of the hour.

I've tried to follow the spirit in which this code seemed to be written, and also the style of the commit history. We would love to see this change make its way back to the original repo as we think it is adding some value that could be useful to other users. Let us know what you think!

Thanks! ❤️ 