### PR TITLE
fix: quote GITHUB_LOG_METRIC_COLLECTION env var & remove default

### DIFF
--- a/helm/github-rate-limits-prometheus-exporter/templates/deployment.yaml
+++ b/helm/github-rate-limits-prometheus-exporter/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: GITHUB_LOG_METRIC_COLLECTION
-              value: {{ .Values.logging.logMetricCollection | default "true" }}
+              value: {{ .Values.logging.logMetricCollection | quote }}
           {{- if eq .Values.github.authType "app" }}
             - name: GITHUB_AUTH_TYPE
               value: {{ .Values.github.authType | upper | quote }}


### PR DESCRIPTION
Having issues deploying the charts as the environment variable `GITHUB_LOG_METRIC_COLLECTION` needs to be a string rather than a bool. See:

`"github-rate-limits-prometheus-exporter/github-rate-limits-prometheus-exporter-deploy.yaml": Deployment in version "v1" cannot be handled as a Deployment: json: cannot unmarshal bool into Go struct field EnvVar.spec.template.spec.containers.env.value of type string`

Also removed the default value as it's defaulted `true` in values.