### PR TITLE
[GB-1]Minor refactoring and logging

### DIFF
--- a/internal/github_client/github_client.go
+++ b/internal/github_client/github_client.go
@@ -43,12 +43,13 @@ func InitConfig() GithubClient {
 	// determine type (app or pat)
 	var auth GithubClient
 	authType := utils.GetOSVar("GITHUB_AUTH_TYPE")
-	if authType == "PAT" {
+	switch authType {
+	case "PAT":
 		auth = &TokenConfig{
 			Token: utils.GetOSVar("GITHUB_TOKEN"),
 		}
 
-	} else if authType == "APP" {
+	case "APP":
 		appID, _ := strconv.ParseInt(utils.GetOSVar("GITHUB_APP_ID"), 10, 64)
 
 		var installationID int64
@@ -64,7 +65,7 @@ func InitConfig() GithubClient {
 			RepoName:       utils.GetOSVar("GITHUB_REPO_NAME"),
 			PrivateKeyPath: utils.GetOSVar("GITHUB_PRIVATE_KEY_PATH"),
 		}
-	} else {
+	default:
 		err := fmt.Errorf("invalid auth type")
 		utils.RespError(err)
 		return nil

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -3,12 +3,27 @@ package utils
 import (
 	"errors"
 	"fmt"
+	"log"
 	"os"
+	"strings"
 )
+
+var verbose bool
+
+func init() {
+	verboseEnv := GetOSVar("VERBOSE")
+	verbose = strings.ToLower(verboseEnv) == "true" || verboseEnv == "1"
+}
 
 func RespError(err error) error {
 	if err != nil {
-		errMsg := fmt.Sprintf("there was an error during the call execution: %s\n", err)
+		errMsg := fmt.Sprintf("there was an error during the call execution: %s", err)
+
+		if verbose {
+			log.SetOutput(os.Stderr)
+			log.Printf("ERROR: %s", errMsg)
+		}
+
 		return errors.New(errMsg)
 	}
 	return nil

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -17,7 +17,7 @@ func init() {
 
 func RespError(err error) error {
 	if err != nil {
-		errMsg := fmt.Sprintf("there was an error during the call execution: %s", err)
+		errMsg := fmt.Sprintf("there was an error during the call execution: %s\n", err)
 
 		if verbose {
 			log.SetOutput(os.Stderr)

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -24,5 +24,5 @@ func TestGetOSVar(t *testing.T) {
 
 func TestRespError(t *testing.T) {
 	err := errors.New("test")
-	assert.Equal(t, errors.New("there was an error during the call execution: test"), RespError(err))
+	assert.Equal(t, errors.New("there was an error during the call execution: test\n"), RespError(err))
 }


### PR DESCRIPTION
now you can specify VERBOSE env variable during the app startup and if **true** or **1** it should send error in the os.stderr